### PR TITLE
unbias match lengths by skipping terminal mismatch

### DIFF
--- a/makeFurDb/makeFurDb.org
+++ b/makeFurDb/makeFurDb.org
@@ -905,7 +905,7 @@ match the forward and the reverse strands by calling the function
 #+begin_export latex
 Inside \ty{matchSeq}, we traverse the sequence in steps of matching
 prefixes. Each match is analyzed and stored before we advance by its
-length.
+length past the mismatching nucleotide.
 #+end_export
 #+begin_src go <<Functions, Pr. \ref{pr:mfd}>>=
   func matchSeq(d []byte, e *esa.Esa, ml []int, rev bool) {
@@ -913,7 +913,7 @@ length.
 		  match := e.MatchPref(d[i:])
 		  //<<Analyze match, Pr. \ref{pr:mfd}>>
 		  //<<Store match, Pr. \ref{pr:mfd}>>
-		  i += match.L
+		  i += match.L + 1
 	  }
   }
 #+end_src


### PR DESCRIPTION
I believe this is wrong. After a match of say ten bases we know that the eleventh is a mismatch. Hence if we are starting from there we are biasing ourselves to a short random match. Instead we need to skip that base and start our next match one base beyond. This is how it is implemented in Phylonium:

https://github.com/EvolBioInf/phylonium/blob/master/src/process.cxx#L280-L281

andi: https://github.com/EvolBioInf/andi/blob/master/src/process.c#L195-L196

(didn't actually test this code, lol).