### PR TITLE
updated doc

### DIFF
--- a/doc/furDoc.tex
+++ b/doc/furDoc.tex
@@ -5,7 +5,7 @@
 
 \title{\ty{fur}: Find Unique Regions}
 \author{Bernhard Haubold}
-\date{\input{date.txt}\!\!, \input{version.txt}}
+\date{\input{date.txt}\hspace{-0.11cm}, \input{version.txt}}
 \maketitle
 
 \tableofcontents
@@ -31,4 +31,3 @@
 % \nowebchunks
 \bibliography{ref}
 \end{document}
-

--- a/doc/intro.tex
+++ b/doc/intro.tex
@@ -91,29 +91,22 @@ while \ty{fur} is normally quick and may be run repeatedly, with
 various parameter combinations.
 
 \begin{table}
-\caption{The ten programs in the package \ty{fur}.}\label{tab:pro}
+\caption{The five programs in the package \ty{fur}.}\label{tab:pro}
 \begin{center}
 \begin{tabular}{rll}
 \hline
 \# & Name & Purpose\\\hline
-1 & \ty{checkPrim} & check primers through \emph{in silico} PCR\\
-2 & \ty{cleanSeq} & remove runs of \ty{N} from \ty{fur} output\\
-3 & \ty{fur2prim} & convert \ty{fur} output to \ty{primer3} input\\
-4 & \ty{fur} & find unique regions\\
-5 & \ty{madis} & match length distribution\\
-6 & \ty{makeFurDb} & construct \ty{fur} database\\
-7 & \ty{prim2fasta} & convert primers from \ty{primer3} output to FASTA\\
-8 & \ty{prim2tab} & convert primers from \ty{primer3} output to table\\
-9 & \ty{senSpec} & compute the sensitivity an specificity of \ty{fur}
-output\\
-10 & \ty{stream} & compare streaming strategies for \ty{makeFurDb}\\
+1 & \ty{cleanSeq} & remove runs of \ty{N} from \ty{fur} output\\
+2 & \ty{fur} & find unique regions\\
+3 & \ty{madis} & match length distribution\\
+4 & \ty{makeFurDb} & construct \ty{fur} database\\
+5 & \ty{stream} & compare streaming strategies for \ty{makeFurDb}\\
 \hline
 \end{tabular}
 \end{center}
 \end{table}
 
 Apart from \ty{makeFurDb} and \ty{fur}, this package also contains
-six auxiliary programs for cleaning the output of \ty{fur}, assessing
-its quality, and extracting primers from it (Table~\ref{tab:pro}). The
-application of these auxiliary programs is also demonstrated in the
-tutorial.
+three auxiliary programs for cleaning the output of \ty{fur},
+simulating match length distribution, and comparing \ty{makeFurDb}
+streaming strategies (Table~\ref{tab:pro}).


### PR DESCRIPTION
I have removed the mention of primer-design-related programs from the intro. 
Also, the two "negative spaces" between version and date on the title page caused an error during doc compilation, so I replaced them with `hspace` (as in `prim`).